### PR TITLE
use a minimal jupyter configuration

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -1,6 +1,7 @@
 # See docs at: https://mystmd.org/guide/frontmatter
 version: 1
 project:
+  id: msa-em-article-template-1
   title: Article template for Elemental Microscopy
   short_title: EM Template
   keywords: []
@@ -38,19 +39,13 @@ project:
     PDF: portable document format
     STEM: scanning transmission electron microscopy
   banner: banner.png
-  jupyter:
-    #    server:
-    #      url: http://localhost:8686
-    #      token: 60c1661cc408f978c309d04157af55c9588ff9557c9380e4fb50785750703da6
-    binder:
-      url: https://xhrtcvh6l53u.curvenote.dev/services/binder/
-      repo: msa-em/em-template
-      ref: main
+  jupyter: true
 site:
   template: book-theme
   title: EM Template
   options:
-    logo_text: EM Template
+    logo_text:
+      EM Template
       #  projects:
       #    - slug: myst
       #      path: .


### PR DESCRIPTION
@gvarnavi I've switched to this minimal `jupyter: true` configuration for the template, this just means we don't have url's to the services hard coded in the `yml` file as these could change.

(In this configuration, the `github` field is used as the repository and `main`/`HEAD` is the default ref)

This would essentially mean when working locally someone would be hitting the public binder by default, but can test on the journal binder using the draft submission mechanism that we have. We can onboard you onto that at some point soon!